### PR TITLE
Feature modify schema for new coloc data ak

### DIFF
--- a/finngen_common_data_model/colocalization.py
+++ b/finngen_common_data_model/colocalization.py
@@ -329,7 +329,7 @@ class Colocalization(Kwargs, JSONifiable):
                                                     "clpp", "clpa",
                                                     "len_cs1", "len_cs2", "len_inter", 
                                                     "source2_displayname", 
-                                                    "beta1", "beta2", "pval1", "pval2", 'PP.H4.abf',
+                                                    "beta1", "beta2", "pval1", "pval2", 'pp_h4_abf',
                                                     "colocalization_id"]}
         c["variants"] = list(map(lambda v: CausalVariant(**v.kwargs_rep()), self.variants))
         return c


### PR DESCRIPTION
- Updated schema for clpa, clpp, beta1, beta2, pval1, pval2 columns in colocalization table (changed to float allowing NULL), added a new column pp_h4_abf. 
- Updated schema for pip1, pip2 columns in causal_variant table (changed to float allowing NULL).